### PR TITLE
AB#1738 video source now reads from position source and adds position to frame

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,11 @@
 video-source-py (###RELEASE_VERSION###) unstable; urgency=medium
 
+  * add position to VideoFraem object.
+
+ -- Markus Zarbock <foss@starwit.de>  Fri, 01 Aug 2025 12:00:00 +0000
+
+video-source-py (1.2.5) unstable; urgency=medium
+
   * Sign debian package.
   * Stream lined dependencies.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -185,23 +185,21 @@ twisted = ["twisted"]
 
 [[package]]
 name = "protobuf"
-version = "4.25.8"
+version = "6.31.1"
 description = ""
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "protobuf-4.25.8-cp310-abi3-win32.whl", hash = "sha256:504435d831565f7cfac9f0714440028907f1975e4bed228e58e72ecfff58a1e0"},
-    {file = "protobuf-4.25.8-cp310-abi3-win_amd64.whl", hash = "sha256:bd551eb1fe1d7e92c1af1d75bdfa572eff1ab0e5bf1736716814cdccdb2360f9"},
-    {file = "protobuf-4.25.8-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:ca809b42f4444f144f2115c4c1a747b9a404d590f18f37e9402422033e464e0f"},
-    {file = "protobuf-4.25.8-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:9ad7ef62d92baf5a8654fbb88dac7fa5594cfa70fd3440488a5ca3bfc6d795a7"},
-    {file = "protobuf-4.25.8-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:83e6e54e93d2b696a92cad6e6efc924f3850f82b52e1563778dfab8b355101b0"},
-    {file = "protobuf-4.25.8-cp38-cp38-win32.whl", hash = "sha256:27d498ffd1f21fb81d987a041c32d07857d1d107909f5134ba3350e1ce80a4af"},
-    {file = "protobuf-4.25.8-cp38-cp38-win_amd64.whl", hash = "sha256:d552c53d0415449c8d17ced5c341caba0d89dbf433698e1436c8fa0aae7808a3"},
-    {file = "protobuf-4.25.8-cp39-cp39-win32.whl", hash = "sha256:077ff8badf2acf8bc474406706ad890466274191a48d0abd3bd6987107c9cde5"},
-    {file = "protobuf-4.25.8-cp39-cp39-win_amd64.whl", hash = "sha256:f4510b93a3bec6eba8fd8f1093e9d7fb0d4a24d1a81377c10c0e5bbfe9e4ed24"},
-    {file = "protobuf-4.25.8-py3-none-any.whl", hash = "sha256:15a0af558aa3b13efef102ae6e4f3efac06f1eea11afb3a57db2901447d9fb59"},
-    {file = "protobuf-4.25.8.tar.gz", hash = "sha256:6135cf8affe1fc6f76cced2641e4ea8d3e59518d1f24ae41ba97bcad82d397cd"},
+    {file = "protobuf-6.31.1-cp310-abi3-win32.whl", hash = "sha256:7fa17d5a29c2e04b7d90e5e32388b8bfd0e7107cd8e616feef7ed3fa6bdab5c9"},
+    {file = "protobuf-6.31.1-cp310-abi3-win_amd64.whl", hash = "sha256:426f59d2964864a1a366254fa703b8632dcec0790d8862d30034d8245e1cd447"},
+    {file = "protobuf-6.31.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:6f1227473dc43d44ed644425268eb7c2e488ae245d51c6866d19fe158e207402"},
+    {file = "protobuf-6.31.1-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:a40fc12b84c154884d7d4c4ebd675d5b3b5283e155f324049ae396b95ddebc39"},
+    {file = "protobuf-6.31.1-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:4ee898bf66f7a8b0bd21bce523814e6fbd8c6add948045ce958b73af7e8878c6"},
+    {file = "protobuf-6.31.1-cp39-cp39-win32.whl", hash = "sha256:0414e3aa5a5f3ff423828e1e6a6e907d6c65c1d5b7e6e975793d5590bdeecc16"},
+    {file = "protobuf-6.31.1-cp39-cp39-win_amd64.whl", hash = "sha256:8764cf4587791e7564051b35524b72844f845ad0bb011704c3736cce762d8fe9"},
+    {file = "protobuf-6.31.1-py3-none-any.whl", hash = "sha256:720a6c7e6b77288b85063569baae8536671b39f15cc22037ec7045658d80489e"},
+    {file = "protobuf-6.31.1.tar.gz", hash = "sha256:d8cac4c982f0b957a4dc73a80e2ea24fab08e679c0de9deb835f4a12d69aca9a"},
 ]
 
 [[package]]
@@ -756,7 +754,7 @@ typing-extensions = ">=4.12.0"
 
 [[package]]
 name = "visionapi"
-version = "3.2.0"
+version = "3.3.0"
 description = ""
 optional = false
 python-versions = "^3.10"
@@ -765,13 +763,13 @@ files = []
 develop = false
 
 [package.dependencies]
-protobuf = "^4.23.0"
+protobuf = "6.31.1"
 
 [package.source]
 type = "git"
 url = "https://github.com/starwit/vision-api.git"
-reference = "3.2.0"
-resolved_reference = "cb43b088ceb93060822cb71f5f4b3c1888baddb2"
+reference = "3.3.0"
+resolved_reference = "b7e8093174149767cdcbaeb2272ef9bd623b5425"
 subdirectory = "python/visionapi"
 
 [[package]]
@@ -803,4 +801,4 @@ subdirectory = "python"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "964e31545751a24cf9dc8502637e93fa21ac36717548a4e13ad59ee09ad43051"
+content-hash = "6186d9ebaddb6c360f10af2a1002dcc16ca5afd875129d7e9bdca12bdcf6deb4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = "AGPL3"
 python = "^3.10"
 pydantic = "^2.0.0"
 opencv-python = "^4.7.0.72"
-visionapi = { git = "https://github.com/starwit/vision-api.git", subdirectory = "python/visionapi", tag = "3.2.0" }
+visionapi = { git = "https://github.com/starwit/vision-api.git", subdirectory = "python/visionapi", tag = "3.3.0" }
 visionlib = { git = "https://github.com/starwit/vision-lib.git", subdirectory = "python", tag = "0.11.2" }
 redis = "^5.0.0"
 pydantic-settings = "^2.0.3"

--- a/settings.template.yaml
+++ b/settings.template.yaml
@@ -13,9 +13,14 @@ scale_width: 0
 mask_path: null
 # How long to wait in seconds in case the connection is lost before the next retry
 reconnect_backoff_time: 1
+# max delay in ms between frame time and position update time
+max_position_delay: 1000
+# if true, frames will be forwarded without position
+skip_frames_if_no_position: False
+
 log_level: DEBUG
 redis:
-  host: redis-host
+  host: redis
   port: 6379
 
 prometheus_port: 8000

--- a/settings.template.yaml
+++ b/settings.template.yaml
@@ -19,7 +19,7 @@ max_position_delay: 1000
 # if true, video source tries to read from position source current location
 add_position_to_frame: True
 # if true, frames will be forwarded without position
-skip_frames_if_no_position: False
+drop_frames_if_no_position: False
 
 log_level: DEBUG
 redis:

--- a/settings.template.yaml
+++ b/settings.template.yaml
@@ -14,12 +14,13 @@ mask_path: null
 # How long to wait in seconds in case the connection is lost before the next retry
 reconnect_backoff_time: 1
 
-# max delay in ms between frame time and position update time
-max_position_delay: 1000
-# if true, video source tries to read from position source current location
-add_position_to_frame: True
-# if true, frames will be forwarded without position
-drop_frames_if_no_position: False
+position_configuration:
+  # max delay in ms between frame time and position update time
+  max_position_skew: 1000
+  # if true, video source tries to read from position source current location
+  add_position_to_frame: True
+  # if true, frames will be forwarded without position
+  drop_frames_if_no_position: False
 
 log_level: DEBUG
 redis:

--- a/settings.template.yaml
+++ b/settings.template.yaml
@@ -13,8 +13,11 @@ scale_width: 0
 mask_path: null
 # How long to wait in seconds in case the connection is lost before the next retry
 reconnect_backoff_time: 1
+
 # max delay in ms between frame time and position update time
 max_position_delay: 1000
+# if true, video source tries to read from position source current location
+add_position_to_frame: True
 # if true, frames will be forwarded without position
 skip_frames_if_no_position: False
 

--- a/video_source_py/config.py
+++ b/video_source_py/config.py
@@ -12,6 +12,10 @@ class RedisConfig(BaseModel):
     port: Annotated[int, Field(ge=1, le=65536)] = 6379
     output_stream_prefix: str = 'videosource'
 
+class PositionConfiguration(BaseModel):
+    max_position_skew: int = 1500
+    add_position_to_frame: bool = True
+    drop_frames_if_no_position: bool = False    
 
 class VideoSourceConfig(BaseSettings):
     id: str
@@ -23,10 +27,8 @@ class VideoSourceConfig(BaseSettings):
     mask_path: Optional[Path] = None
     log_level: LogLevel = LogLevel.WARNING
     reconnect_backoff_time: float = 1
+    position_configuration: PositionConfiguration = PositionConfiguration()
     redis: RedisConfig = RedisConfig()
-    max_position_delay: int = 1500
-    add_position_to_frame: bool = True
-    skip_frames_if_no_position: bool = False
     prometheus_port: Annotated[int, Field(gt=1024, le=65536)] = 8000
 
     model_config = SettingsConfigDict(env_nested_delimiter='__')

--- a/video_source_py/config.py
+++ b/video_source_py/config.py
@@ -24,6 +24,8 @@ class VideoSourceConfig(BaseSettings):
     log_level: LogLevel = LogLevel.WARNING
     reconnect_backoff_time: float = 1
     redis: RedisConfig = RedisConfig()
+    max_position_delay: int = 1500
+    skip_frames_if_no_position: bool = False
     prometheus_port: Annotated[int, Field(gt=1024, le=65536)] = 8000
 
     model_config = SettingsConfigDict(env_nested_delimiter='__')

--- a/video_source_py/config.py
+++ b/video_source_py/config.py
@@ -25,6 +25,7 @@ class VideoSourceConfig(BaseSettings):
     reconnect_backoff_time: float = 1
     redis: RedisConfig = RedisConfig()
     max_position_delay: int = 1500
+    add_position_to_frame: bool = True
     skip_frames_if_no_position: bool = False
     prometheus_port: Annotated[int, Field(gt=1024, le=65536)] = 8000
 

--- a/video_source_py/videosource.py
+++ b/video_source_py/videosource.py
@@ -129,7 +129,6 @@ class VideoSource:
             cv2.subtract(src1=frame, src2=frame, dst=frame, mask=self._mask)
             
     def _get_location(self, frame) -> VideoFrame:
-        # read position data and parse it into PositionMessage
         streamPositionMessage = self._redis_client.xrevrange('positionsource:self', count=1)
         positionMessage = PositionMessage()
         if len(streamPositionMessage) > 0:

--- a/video_source_py/videosource.py
+++ b/video_source_py/videosource.py
@@ -97,15 +97,16 @@ class VideoSource:
         else:
             msg.frame.frame_data = frame.tobytes()
         
-        position = self._get_location(msg.frame)
-        if position is not None:
-            msg.frame.camera_location.CopyFrom(position)
-        else:
-            if self.config.skip_frames_if_no_position:
-                root_logger.debug('no position data - forwarding detections without position')
+        if self.config.add_position_to_frame:        
+            position = self._get_location(msg.frame)
+            if position is not None:
+                msg.frame.camera_location.CopyFrom(position)
             else:
-                root_logger.error('no position data - not processing Detections')
-                return None
+                if self.config.skip_frames_if_no_position:
+                    root_logger.debug('no position data - forwarding detections without position')
+                else:
+                    root_logger.error('no position data - not processing Detections')
+                    return None
 
         return msg.SerializeToString()
     

--- a/video_source_py/videosource.py
+++ b/video_source_py/videosource.py
@@ -128,7 +128,7 @@ class VideoSource:
             # This works by subtracting the pixel value from itself (i.e. setting it to 0) wherever the mask is not 0
             cv2.subtract(src1=frame, src2=frame, dst=frame, mask=self._mask)
             
-    def _get_location(self, frame) -> VideoFrame:
+    def _get_location(self, frame) -> GeoCoordinate:
         streamPositionMessage = self._redis_client.xrevrange('positionsource:self', count=1)
         positionMessage = PositionMessage()
         if len(streamPositionMessage) > 0:

--- a/video_source_py/videosource.py
+++ b/video_source_py/videosource.py
@@ -1,16 +1,19 @@
 import logging
 
-logging.basicConfig(format='%(asctime)s %(name)-15s %(levelname)-10s %(message)s')
-root_logger = logging.getLogger()
+logging.basicConfig(format='%(asctime)s %(name)-15s %(levelname)-8s %(processName)-10s %(message)s')
+root_logger = logging.getLogger(__name__)
 
 import time
 from pathlib import Path
 from typing import Any
 
+import redis
+import pybase64
 import cv2
 import numpy as np
 from prometheus_client import Counter, Histogram, Summary
-from visionapi.sae_pb2 import SaeMessage, Shape, VideoFrame
+from visionapi.sae_pb2 import SaeMessage, Shape, VideoFrame, PositionMessage
+from visionapi.common_pb2 import GeoCoordinate
 
 from .config import VideoSourceConfig
 from .framegrabber import FrameGrabber
@@ -36,6 +39,8 @@ class VideoSource:
         if config.jpeg_encode:
             from turbojpeg import TurboJPEG
             self._jpeg = TurboJPEG()
+        
+        self._redis_client = redis.Redis(config.redis.host, config.redis.port)
 
     def _load_mask(self, path: Path) -> np.ndarray:
         if not path.is_file():
@@ -69,7 +74,12 @@ class VideoSource:
 
         self._apply_mask(frame)
         
-        return self._to_proto(frame)
+        frame = self._to_proto(frame)
+        
+        if frame is None:
+            return None # skip frame       
+        
+        return frame
 
     def close(self):
         self._framegrabber.stop()
@@ -86,6 +96,16 @@ class VideoSource:
             msg.frame.frame_data_jpeg = self._jpeg.encode(frame, quality=self.config.jpeg_quality)
         else:
             msg.frame.frame_data = frame.tobytes()
+        
+        position = self._get_location(msg.frame)
+        if position is not None:
+            msg.frame.camera_location.CopyFrom(position)
+        else:
+            if self.config.skip_frames_if_no_position:
+                root_logger.debug('no position data - forwarding detections without position')
+            else:
+                root_logger.error('no position data - not processing Detections')
+                return None
 
         return msg.SerializeToString()
     
@@ -111,3 +131,20 @@ class VideoSource:
         if self._mask is not None:
             # This works by subtracting the pixel value from itself (i.e. setting it to 0) wherever the mask is not 0
             cv2.subtract(src1=frame, src2=frame, dst=frame, mask=self._mask)
+            
+    def _get_location(self, frame) -> VideoFrame:
+        # read position data and parse it into PositionMessage
+        streamPositionMessage = self._redis_client.xrevrange('positionsource:self', count=1)
+        decodedPositionMessage = pybase64.b64decode(streamPositionMessage[0][1][b'proto_data_b64'])
+        positionMessage = PositionMessage()
+        positionMessage.ParseFromString(decodedPositionMessage)
+        if positionMessage.fix == False:
+            root_logger.debug('no position fix')
+            return None
+        if abs(positionMessage.timestamp_utc_ms - frame.timestamp_utc_ms) > self.config.max_position_delay:
+            root_logger.debug('position data and frame timestamp differ more than ' + str(self.config.max_position_delay))
+            return None
+        result = GeoCoordinate()
+        result.latitude = positionMessage.geo_coordinate.latitude
+        result.longitude = positionMessage.geo_coordinate.longitude
+        return result


### PR DESCRIPTION
For every frame video source no tries to add position from position source. Can be skipped.

## Motivation and Context
To support dynamic position deployments, video source must add position on capture time. Components using frames then can use timestamp + position for their respective computations.

## How has this been tested?
Local

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
